### PR TITLE
fix bug where sales order line amount is not calculated automatically

### DIFF
--- a/OMS-API/Migrations/CreateFunctions.sql
+++ b/OMS-API/Migrations/CreateFunctions.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE procedure public."CalcSalesOrderLineAmount" ( "lineId" integer)
+	LANGUAGE plpgsql
+	AS $$
+declare
+	amount decimal := 0;
+begin
+	select line."Quantity" * i."UnitPrice" into amount
+	from "SalesOrderLines" line join "Items" i on line."ItemId" = i."Id"
+	where line."Id" = "lineId"
+    limit 1;
+	update "SalesOrderLines" set "Amount" = amount
+	where "SalesOrderLines"."Id" = "lineId";
+end;
+$$;

--- a/OMS-API/Services/SalesOrderLineService.cs
+++ b/OMS-API/Services/SalesOrderLineService.cs
@@ -88,7 +88,7 @@ namespace OMSAPI.Services
 
         private bool UpdateLineAmount(int id) {
             try {
-                var res = _context.Database.ExecuteSqlCommand($"CALL public.\"CalculateSalesOrderLineAmount\"({id})");
+                var res = _context.Database.ExecuteSqlCommand($"CALL public.\"CalcSalesOrderLineAmount\"({id});");
             }
             catch(Exception e) {
                 Console.WriteLine(e.Message);


### PR DESCRIPTION
This fix addresses #1. There was inconsistency in the database stored procedures that had to be cleared.